### PR TITLE
Support Office installations without requiring Outlook for MAPI detection

### DIFF
--- a/crates/mapi-sys/Cargo.toml
+++ b/crates/mapi-sys/Cargo.toml
@@ -22,6 +22,7 @@ targets = [
 default = [ "olmapi32" ]
 olmapi32 = [
     "windows/Win32_System_ApplicationInstallationAndServicing",
+    "windows/Win32_System_Registry",
 ]
 
 [dependencies]

--- a/crates/mapi-sys/src/installation.rs
+++ b/crates/mapi-sys/src/installation.rs
@@ -1,9 +1,11 @@
 use std::path::PathBuf;
 
-use windows_core::{PCWSTR, w};
+use windows::Win32::System::Registry::*;
+use windows_core::{PCWSTR, w, HSTRING};
 
 use crate::load_mapi::{OUTLOOK_QUALIFIED_COMPONENTS, get_outlook_mapi_path};
 
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Architecture {
     X64,
     X86,
@@ -14,7 +16,37 @@ pub enum InstallationState {
     NotInstalled,
 }
 
+#[derive(Debug, Clone)]
+pub struct OfficeInstallation {
+    pub architecture: Architecture,
+    pub version: String,
+    pub install_path: PathBuf,
+    pub mapi_dll_path: PathBuf,
+}
+
+// Registry paths for Office installations
+// Only checking Office 16.0+ as earlier versions don't have the MAPI support we need
+const OFFICE_REGISTRY_PATHS: &[&str] = &[
+    r"SOFTWARE\Microsoft\Office\ClickToRun\Configuration",  // Modern Office 365/2016+
+    r"SOFTWARE\Microsoft\Office\16.0\Common\InstallRoot",   // Traditional MSI Office 2016
+];
+
 pub fn check_outlook_mapi_installation() -> InstallationState {
+    // First try the original Outlook-specific method for backward compatibility
+    if let InstallationState::Installed(arch, path) = check_outlook_installation_legacy() {
+        return InstallationState::Installed(arch, path);
+    }
+
+    // Then check for Office installations via registry
+    if let Some(installation) = find_office_installations().into_iter().next() {
+        return InstallationState::Installed(installation.architecture, installation.mapi_dll_path);
+    }
+
+    InstallationState::NotInstalled
+}
+
+/// Legacy method using Windows Installer API to find Outlook installations
+fn check_outlook_installation_legacy() -> InstallationState {
     const OUTLOOK_QUALIFIERS: [(Architecture, PCWSTR); 2] = [
         (Architecture::X64, w!("outlook.x64.exe")),
         (Architecture::X86, w!("outlook.exe")),
@@ -29,4 +61,147 @@ pub fn check_outlook_mapi_installation() -> InstallationState {
     }
 
     InstallationState::NotInstalled
+}
+
+/// Find all Office installations that include MAPI support
+pub fn find_office_installations() -> Vec<OfficeInstallation> {
+    let mut installations = Vec::new();
+    
+    // Check both 64-bit and 32-bit registry views
+    for &wow64_flag in &[KEY_WOW64_64KEY, KEY_WOW64_32KEY] {
+        let arch = if wow64_flag == KEY_WOW64_64KEY {
+            Architecture::X64
+        } else {
+            Architecture::X86
+        };
+
+        installations.extend(check_office_registry_paths(arch, wow64_flag));
+    }
+
+    // Remove duplicates and sort by version (newest first)
+    installations.sort_by(|a, b| b.version.cmp(&a.version));
+    installations.dedup_by(|a, b| a.install_path == b.install_path);
+    
+    installations
+}
+
+fn check_office_registry_paths(arch: Architecture, wow64_flag: REG_SAM_FLAGS) -> Vec<OfficeInstallation> {
+    let mut installations = Vec::new();
+
+    for &registry_path in OFFICE_REGISTRY_PATHS {
+        if let Some(installation) = check_office_registry_path(registry_path, arch, wow64_flag) {
+            installations.push(installation);
+        }
+    }
+
+    installations
+}
+
+fn check_office_registry_path(registry_path: &str, arch: Architecture, wow64_flag: REG_SAM_FLAGS) -> Option<OfficeInstallation> {
+    unsafe {
+        let mut hkey = HKEY::default();
+        let path_hstring = HSTRING::from(registry_path);
+        
+        if RegOpenKeyExW(
+            HKEY_LOCAL_MACHINE,
+            &path_hstring,
+            Some(0),
+            KEY_READ | wow64_flag,
+            &mut hkey,
+        ).is_ok() {
+            
+            // Try to get the install path - different key names for different registry paths
+            let install_path = if registry_path.contains("ClickToRun") {
+                // For ClickToRun installations, get InstallationPath and construct root\Office16 path
+                if let Some(base_path) = read_registry_string(&hkey, w!("InstallationPath")) {
+                    let mut office_path = PathBuf::from(base_path);
+                    office_path.push("root");
+                    office_path.push("Office16");
+                    Some(office_path)
+                } else {
+                    None
+                }
+            } else {
+                // For traditional MSI installations, use the Path key directly
+                read_registry_string(&hkey, w!("Path")).map(PathBuf::from)
+            };
+
+            if let Some(install_path) = install_path {
+                // Check for MAPI DLL in the installation
+                let mapi_paths = [
+                    install_path.join("olmapi32.dll"),
+                    install_path.join("mapi32.dll"),
+                ];
+
+                for mapi_path in &mapi_paths {
+                    if mapi_path.exists() {
+                        let version = extract_version_from_path(registry_path);
+                        let _ = RegCloseKey(hkey);
+                        return Some(OfficeInstallation {
+                            architecture: arch,
+                            version,
+                            install_path: install_path.clone(),
+                            mapi_dll_path: mapi_path.clone(),
+                        });
+                    }
+                }
+            }
+            
+            let _ = RegCloseKey(hkey);
+        }
+    }
+
+    None
+}
+
+fn read_registry_string(hkey: &HKEY, value_name: PCWSTR) -> Option<String> {
+    unsafe {
+        let mut buffer_size = 0u32;
+        
+        // Get the required buffer size
+        if RegQueryValueExW(
+            *hkey,
+            value_name,
+            None,
+            None,
+            None,
+            Some(&mut buffer_size),
+        ).is_ok() && buffer_size > 0 {
+            
+            let mut buffer = vec![0u16; (buffer_size / 2) as usize];
+            let mut actual_size = buffer_size;
+            
+            if RegQueryValueExW(
+                *hkey,
+                value_name,
+                None,
+                None,
+                Some(buffer.as_mut_ptr() as *mut u8),
+                Some(&mut actual_size),
+            ).is_ok() {
+                // Remove null terminator and convert to String
+                if let Some(null_pos) = buffer.iter().position(|&x| x == 0) {
+                    buffer.truncate(null_pos);
+                }
+                return String::from_utf16(&buffer).ok();
+            }
+        }
+    }
+    
+    None
+}
+
+fn extract_version_from_path(registry_path: &str) -> String {
+    // Extract version info from registry path
+    if registry_path.contains("ClickToRun") {
+        "16.0-ClickToRun".to_string()
+    } else if let Some(start) = registry_path.find(r"\Office\") {
+        let version_start = start + 8; // Length of "\Office\"
+        if let Some(end) = registry_path[version_start..].find('\\') {
+            return registry_path[version_start..version_start + end].to_string();
+        }
+        "16.0-MSI".to_string()
+    } else {
+        "Unknown".to_string()
+    }
 }


### PR DESCRIPTION
### Problem
The existing MAPI detection used Outlook-specific component GUIDs with the Windows Installer API ([MsiProvideQualifiedComponentW](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)). However, recent M365 versions of Office will now include MAPI libraries even when Outlook is not installed. The old Outlook-specific detection method failed to find these MAPI libraries, causing checks to fail when attempting to verify MAPI installation.

### Solution
Added registry-based Office detection that finds MAPI libraries in any Office installation:
- **ClickToRun installations** (modern Office 365/2016+): `SOFTWARE\Microsoft\Office\ClickToRun\Configuration`
- **MSI installations** (traditional/enterprise): `SOFTWARE\Microsoft\Office\16.0\Common\InstallRoot`
- **Both 64-bit and 32-bit** architectures
- **Backward compatibility** with existing Outlook-specific detection as fallback

### Changes
[installation.rs](https://github.com/josevarela-ms/mapi-rs/pull/1/files#diff-4efeaaaa9a7d8443e2dcd6b50b3eded617623bb825d672195646914674a98904): New registry-based Office detection logic
[load_mapi.rs](https://github.com/josevarela-ms/mapi-rs/pull/1/files#diff-07f143b2bd6dda25466cc79a82dcc03b47772b938711d85e639dacfdc783659b): Updated `ensure_olmapi32()` to use new detection
[Cargo.toml](https://github.com/josevarela-ms/mapi-rs/pull/1/files#diff-717277a69ce0c9e2b68b3fc520f09587e2f83b0840beeaa71b1533bc747174d3): Added Windows Registry API support

### Results
❌ Before: MAPI initialization failed with Office installations (no Outlook)
✅ After: Successfully detects MAPI in recent Office 16.0+ installation

No breaking changes - fully backward compatible.